### PR TITLE
Add creation date to current app response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ Will return:
 {
 	identity: {
 		id: String,		// unique ID for referencing
-		name: String,	// name of your app, if it has one
+		name: String,		// name of your app, if it has one
+		created: String, 	// creation date of your app
 	}
 }
 ```


### PR DESCRIPTION
I noticed the `/me` endpoint also returns the current app's creation date as a string.

This PR adds the creation date property to the example response object at https://github.com/paylike/api-docs/blob/master/README.md#fetch-current-app