### PR TITLE
added link to new .NET Standard 2.0 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Clients:
 
 - Node.js: https://github.com/paylike/node-api (official)
 - .NET: https://github.com/paylike/Paylike.NET (maintained by [@andronachev](https://github.com/andronachev))
+- .NET Standard 2.0 (.NET Core) https://github.com/mrlund/Paylike.NETstandard (maintained by [@mrlund](https://github.com/mrlund))
 - PHP: https://github.com/paylike/php-api (maintained by [@ionutcalara](https://github.com/ionutcalara))
 - Python: https://pypi.org/project/paylike/ (maintained by [@SuneKjaergaard](https://github.com/SuneKjaergaard))
 - Java: https://github.com/paylike/java-api (maintained by [@jankjr](https://github.com/jankjr))


### PR DESCRIPTION
I finally got my .NET Standard 2.0 version of the Paylike lib into a state where others might find it useful. It's made for .NET Standard 2.0, for projects targeting .NET Core up to 2.1. (.NET Core is the ground-up rebuild of the .NET platform, fully open source, high performance, and cross platform)